### PR TITLE
Begin working on History Move Refactor

### DIFF
--- a/src/board/game.rs
+++ b/src/board/game.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 pub const NORMAL_MODE: u32 = 0;
 
-use super::{actions::{Action, ActionInfo, TheoreticalAction}, fen::FenOptions, pieces::Piece, Board, Rows, Cols, zobrist::ZobristHashTable};
+use super::{actions::{Action, ActionInfo, TheoreticalAction, HistoryMove}, fen::FenOptions, pieces::Piece, Board, Rows, Cols, zobrist::ZobristHashTable};
 
 pub fn get_theoretical_moves_bound<const T: usize>(board: &Board<T>, max_info: ActionInfo) -> Vec<TheoreticalAction> {
     let mut theoretical_moves = Vec::with_capacity((
@@ -38,7 +38,7 @@ pub trait MoveController<const T: usize> : Debug + Send + Sync {
     fn use_pseudolegal(&self) -> bool;
 
     fn add_moves(&self, board: &Board<T>, actions: &mut Vec<Option<Action>>) {}
-    fn make_drop_move(&self, board: &mut Board<T>, action: &Action) {
+    fn make_drop_move(&self, board: &mut Board<T>, action: &Action) -> Option<HistoryMove<T>> {
         panic!("Drop moves aren't supported. Make sure to override `make_drop_move` in your game's MoveController to support them.");
     }
 

--- a/src/board/perft.rs
+++ b/src/board/perft.rs
@@ -38,9 +38,9 @@ impl<'a, const T: usize> Board<'a, T> {
             self.generate_moves(0)
         };
         for node in moves {
-            self.make_move(&node);
+            let undo = self.make_move(&node);
             nodes += self.perft(depth - 1, legality);
-            self.undo_move();
+            self.undo_move(undo);
         }
 
         nodes
@@ -77,11 +77,11 @@ impl<'a, const T: usize> Board<'a, T> {
         let mut nodes = 0;
         let mut branches: Vec<PerftBranch> = vec![];
         for node in self.generate_legal_moves(0) {
-            self.make_move(&node);
+            let undo = self.make_move(&node);
             let results = self.branch_perft(depth - 1);
             nodes += results.nodes;
             branches.push((self.encode_action(&node), results));
-            self.undo_move();
+            self.undo_move(undo);
         }
 
         PerftResults { nodes, branches }

--- a/src/board/pieces/mod.rs
+++ b/src/board/pieces/mod.rs
@@ -71,7 +71,7 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
         piece_type: usize,
         from: BitBoard<T>,
         to: BitBoard<T>,
-    ) {
+    ) -> Option<HistoryMove<T>> {
         let color: usize = action.team as usize;
         let captured_color: usize = if (to & board.state.teams[0]).is_set() {
             0
@@ -108,7 +108,6 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
                 ],
             },
         };
-        board.history.push(history_move);
 
         board.state.teams[captured_color] ^= to;
         board.state.teams[color] ^= from;
@@ -123,6 +122,8 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
         board.state.first_move &= !from;
         board.state.first_move &= !to;
         // We actually don't need to swap the blockers. A blocker will still exist on `to`, just not on `from`.
+
+        Some(history_move)
     }
 
     fn make_normal_move(
@@ -132,10 +133,10 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
         piece_type: usize,
         from: BitBoard<T>,
         to: BitBoard<T>,
-    ) {
+    ) -> Option<HistoryMove<T>> {
         let color: usize = action.team as usize;
 
-        board.history.push(HistoryMove {
+        let history_move = HistoryMove {
             action: Some(*action),
             state: HistoryState::Single {
                 team: IndexedPreviousBoard(color, board.state.teams[color]),
@@ -143,7 +144,7 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
                 all_pieces: PreviousBoard(board.state.all_pieces),
                 first_move: PreviousBoard(board.state.first_move),
             },
-        });
+        };
 
         board.state.teams[color] ^= from;
         board.state.teams[color] |= to;
@@ -155,20 +156,26 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
         board.state.all_pieces |= to;
 
         board.state.first_move &= !from;
+
+        Some(history_move)
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: &Action) {
+    fn make_move(&self, board: &mut Board<T>, action: &Action) -> Option<HistoryMove<T>> {
         if let Some(from) = action.from {
             let from = BitBoard::from_lsb(from);
             let to = BitBoard::from_lsb(action.to);
 
-            if (board.state.all_pieces & to).is_empty() {
-                self.make_normal_move(board, action, action.piece_type, from, to);
+            let history_move = if (board.state.all_pieces & to).is_empty() {
+                self.make_normal_move(board, action, action.piece_type, from, to)
             } else {
-                self.make_capture_move(board, action, action.piece_type, from, to);
-            }
+                self.make_capture_move(board, action, action.piece_type, from, to)
+            };
 
             update_turns(&mut board.state);
+
+            history_move
+        } else {
+            None
         }
     }
 

--- a/src/games/ataxx/controller.rs
+++ b/src/games/ataxx/controller.rs
@@ -24,9 +24,9 @@ impl<const T: usize> MoveController<T> for AtaxxMoveController {
 
             let team_squares = board.state.teams[board.state.moving_team as usize];
 
-            board.make_move(&None);
+            let undo = board.make_move(&None);
             let opposing_moves = board.generate_moves(NORMAL_MODE).len();
-            board.undo_move();
+            board.undo_move(&undo);
             if opposing_moves > 0 && empty_squares.count_ones() > 0 && team_squares.count_ones() > 0  {
                 vec![ None ]
             } else {

--- a/src/games/ataxx/pieces/mod.rs
+++ b/src/games/ataxx/pieces/mod.rs
@@ -65,7 +65,7 @@ impl<const T: usize> Piece<T> for StonePiece {
         base_moves & !(board.state.all_pieces | board.state.gaps)
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: &Action) {
+    fn make_move(&self, board: &mut Board<T>, action: &Action) -> Option<HistoryMove<T>> {
         if let Some(from) = action.from {
             let from = BitBoard::<T>::from_lsb(from);
             let to = BitBoard::<T>::from_lsb(action.to);
@@ -74,7 +74,7 @@ impl<const T: usize> Piece<T> for StonePiece {
             let team = action.team as usize;
             let other_team = board.state.team_lookup[team] as usize;
 
-            board.history.push(HistoryMove {
+            let history_move = HistoryMove {
                 action: Some(*action),
                 state: HistoryState::Any {
                     all_pieces: PreviousBoard(board.state.all_pieces),
@@ -94,7 +94,7 @@ impl<const T: usize> Piece<T> for StonePiece {
                         )),
                     ],
                 },
-            });
+            };
 
             if is_single_move(action) {
                 // Single Moves
@@ -127,6 +127,10 @@ impl<const T: usize> Piece<T> for StonePiece {
             board.state.teams[team] |= to_update;
 
             update_turns(&mut board.state);
+
+            Some(history_move)
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
This is a commit to begin working on a refactor of `make_move` and  `undo_move` to save memory by getting rid of `Board.history`.

Before:
```
board.make_move(&action);
board.undo_move();
```

After:
```
let undo = board.make_move(&action);
board.undo_move(undo);
```
