### PR TITLE
Action-Related Revamping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "monster_chess"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "criterion",
  "fastrand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.2"
+name = "atomic-polyfill"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
 
 [[package]]
 name = "atty"
@@ -42,6 +45,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cast"
@@ -140,6 +149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,10 +219,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -283,6 +320,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,9 +351,9 @@ dependencies = [
 name = "monster_chess"
 version = "0.0.7"
 dependencies = [
- "arrayvec",
  "criterion",
  "fastrand",
+ "heapless",
  "shell-words",
 ]
 
@@ -431,6 +478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +506,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -487,6 +549,21 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "spin"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monster_chess"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 license = "MIT"
 description = "A fairy chess movegen library that can be easily extended to new chess-adjacent games."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["chess", "ataxx", "movegen"]
 debug = true
 
 [dependencies]
-arrayvec = "0.7.2"
 fastrand = "1.9.0"
+heapless = "0.7.16"
 shell-words = "1.1.0"
 
 [dev-dependencies]

--- a/src/bitboard/bitops.rs
+++ b/src/bitboard/bitops.rs
@@ -67,10 +67,10 @@ impl<const T: usize> ops::BitXorAssign<BitBoard<T>> for BitBoard<T> {
     }
 }
 
-impl<const T: usize> ops::Shl<u32> for BitBoard<T> {
+impl<const T: usize> ops::Shl<u16> for BitBoard<T> {
     type Output = BitBoard<T>;
 
-    fn shl(self, rhs: u32) -> Self::Output {
+    fn shl(self, rhs: u16) -> Self::Output {
         if T == 1 {
             return BitBoard {
                 bits: [self.bits[0] << rhs; T],
@@ -84,8 +84,8 @@ impl<const T: usize> ops::Shl<u32> for BitBoard<T> {
     }
 }
 
-impl<const T: usize> ops::ShlAssign<u32> for BitBoard<T> {
-    fn shl_assign(&mut self, mut rhs: u32) {
+impl<const T: usize> ops::ShlAssign<u16> for BitBoard<T> {
+    fn shl_assign(&mut self, mut rhs: u16) {
         if T == 1 {
             self.bits = [self.bits[0] << rhs; T];
             return;
@@ -109,10 +109,10 @@ impl<const T: usize> ops::ShlAssign<u32> for BitBoard<T> {
     }
 }
 
-impl<const T: usize> ops::Shr<u32> for BitBoard<T> {
+impl<const T: usize> ops::Shr<u16> for BitBoard<T> {
     type Output = BitBoard<T>;
 
-    fn shr(self, rhs: u32) -> Self::Output {
+    fn shr(self, rhs: u16) -> Self::Output {
         if T == 1 {
             return BitBoard {
                 bits: [self.bits[0] >> rhs; T],
@@ -126,8 +126,8 @@ impl<const T: usize> ops::Shr<u32> for BitBoard<T> {
     }
 }
 
-impl<const T: usize> ops::ShrAssign<u32> for BitBoard<T> {
-    fn shr_assign(&mut self, mut rhs: u32) {
+impl<const T: usize> ops::ShrAssign<u16> for BitBoard<T> {
+    fn shr_assign(&mut self, mut rhs: u16) {
         if T == 1 {
             self.bits = [self.bits[0] >> rhs; T];
             return;

--- a/src/bitboard/bitscan.rs
+++ b/src/bitboard/bitscan.rs
@@ -17,20 +17,20 @@ impl Direction {
 
 impl<const T: usize> BitBoard<T> {
     /// A forward bitscan, which finds the least significant 1-bit.
-    pub fn bitscan_forward(&self) -> u32 {
+    pub fn bitscan_forward(&self) -> u16 {
         assert!(
             self.is_set(),
             "Bitscan Forward only works for non-empty BitBoards."
         );
 
         if T == 1 {
-            self.bits[0].trailing_zeros()
+            self.bits[0].trailing_zeros() as u16
         } else {
-            let mut zeros: u32 = 0;
+            let mut zeros: u16 = 0;
             for i in (0..T).rev() {
                 let data = self.bits[i];
                 if data != 0 {
-                    zeros += data.trailing_zeros();
+                    zeros += data.trailing_zeros() as u16;
                     break;
                 }
 
@@ -41,30 +41,30 @@ impl<const T: usize> BitBoard<T> {
     }
 
     /// A reverse bitscan, which finds the most significant 1-bit.
-    pub fn bitscan_reverse(&self) -> u32 {
+    pub fn bitscan_reverse(&self) -> u16 {
         assert!(
             self.is_set(),
             "Bitscan Reverse only works for non-empty BitBoards."
         );
 
         if T == 1 {
-            127 - self.bits[0].leading_zeros()
+            127 - self.bits[0].leading_zeros() as u16
         } else {
-            let mut zeros: u32 = 0;
+            let mut zeros: u16 = 0;
             for i in 0..T {
                 let data = self.bits[i];
                 if data != 0 {
-                    zeros += data.leading_zeros();
+                    zeros += data.leading_zeros() as u16;
                     break;
                 }
 
                 zeros += 128;
             }
-            (((T as u32) * 128) - 1) - zeros
+            (((T as u16) * 128) - 1) - zeros
         }
     }
 
-    pub fn bitscan(&self, direction: Direction) -> u32 {
+    pub fn bitscan(&self, direction: Direction) -> u16 {
         match direction {
             Direction::LEFT => self.bitscan_forward(),
             Direction::RIGHT => self.bitscan_reverse(),

--- a/src/bitboard/shifts.rs
+++ b/src/bitboard/shifts.rs
@@ -3,35 +3,35 @@ use crate::board::Cols;
 use super::BitBoard;
 
 impl<const T: usize> BitBoard<T> {
-    pub fn up(&self, shift: u32, cols: Cols) -> BitBoard<T> {
+    pub fn up(&self, shift: u16, cols: Cols) -> BitBoard<T> {
         *self >> shift * (cols)
     }
 
-    pub fn down(&self, shift: u32, cols: Cols) -> BitBoard<T> {
+    pub fn down(&self, shift: u16, cols: Cols) -> BitBoard<T> {
         *self << shift * (cols)
     }
 
-    pub fn right(&self, shift: u32) -> BitBoard<T> {
+    pub fn right(&self, shift: u16) -> BitBoard<T> {
         *self << shift
     }
 
-    pub fn left(&self, shift: u32) -> BitBoard<T> {
+    pub fn left(&self, shift: u16) -> BitBoard<T> {
         *self >> shift
     }
 
-    pub fn up_mut(&mut self, shift: u32, cols: Cols) {
+    pub fn up_mut(&mut self, shift: u16, cols: Cols) {
         *self >>= shift * (cols);
     }
 
-    pub fn down_mut(&mut self, shift: u32, cols: Cols) {
+    pub fn down_mut(&mut self, shift: u16, cols: Cols) {
         *self <<= shift * (cols);
     }
 
-    pub fn right_mut(&mut self, shift: u32) {
+    pub fn right_mut(&mut self, shift: u16) {
         *self <<= shift;
     }
 
-    pub fn left_mut(&mut self, shift: u32) {
+    pub fn left_mut(&mut self, shift: u16) {
         *self >>= shift;
     }
 }

--- a/src/bitboard/util.rs
+++ b/src/bitboard/util.rs
@@ -17,19 +17,19 @@ impl<const T: usize> BitBoard<T> {
         BitBoard { bits: arr }
     }
 
-    pub fn from_lsb(bit: u32) -> BitBoard<T> {
+    pub fn from_lsb(bit: u16) -> BitBoard<T> {
         BitBoard::<T>::from_element(1) << bit
     }
 
-    pub fn from_msb(bit: u32) -> BitBoard<T> {
+    pub fn from_msb(bit: u16) -> BitBoard<T> {
         !(BitBoard::<T>::max() >> 1) >> bit
     }
 
-    pub fn starting_at_lsb(bit: u32, length: u32) -> BitBoard<T> {
+    pub fn starting_at_lsb(bit: u16, length: u16) -> BitBoard<T> {
         (BitBoard::<T>::from_lsb(length) - BitBoard::<T>::from_element(1)) << bit
     }
 
-    pub fn has_bit(self, bit: u32) -> bool {
+    pub fn has_bit(self, bit: u16) -> bool {
         (self & (BitBoard::<T>::from_element(1) << bit)).is_set()
     }
 
@@ -121,7 +121,7 @@ impl<const T: usize> BitBoard<T> {
         bits
     }
 
-    pub fn iter_set_bits(mut self, end: u32) -> BitIterator<T> {
+    pub fn iter_set_bits(mut self, end: u16) -> BitIterator<T> {
         BitIterator(self, end)
     }
 
@@ -144,10 +144,10 @@ impl<const T: usize> BitBoard<T> {
     }
 }
 
-pub struct BitIterator<const T: usize>(pub BitBoard<T>, u32);
+pub struct BitIterator<const T: usize>(pub BitBoard<T>, u16);
 
 impl<const T: usize> Iterator for BitIterator<T> {
-    type Item = u32;
+    type Item = u16;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.0.is_set() {

--- a/src/board/actions.rs
+++ b/src/board/actions.rs
@@ -7,7 +7,7 @@ pub enum UndoMoveError {
     NoHistoryMoves,
 }
 
-pub type ActionInfo = usize;
+pub type ActionInfo = u16;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Action {

--- a/src/board/actions.rs
+++ b/src/board/actions.rs
@@ -11,9 +11,9 @@ pub type ActionInfo = usize;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Action {
-    pub from: Option<u32>,
-    pub to: u32,
-    pub team: u32,
+    pub from: Option<u16>,
+    pub to: u16,
+    pub team: u16,
     pub piece_type: PieceType,
 
     /// Moves can store extra information both for specifying additional variants of a move.
@@ -29,8 +29,8 @@ pub struct Action {
 /// It's mainly there for Neural Networks to be able to index moves.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct TheoreticalAction {
-    pub from: Option<u32>,
-    pub to: u32,
+    pub from: Option<u16>,
+    pub to: u16,
     pub info: ActionInfo
 }
 

--- a/src/board/actions.rs
+++ b/src/board/actions.rs
@@ -67,7 +67,12 @@ pub enum HistoryState<const T: usize> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HistoryMove<const T: usize> {
     pub action: Move,
-    pub state: HistoryState<T>,
+    // When undoing moves, we need to make sure we don't mess up our `history` information with the last `n` moves, because movegen will still be using it for say, en passant.
+    // If we look say, 10 ply ahead, and get rid of all previous history moves, we won't remember our en passant info at say 1 ply.
+    // To solve this, we store `first_history_move`.
+    // If we need to get rid of `history[0]` to make space for our latest move, we'll put it here, so once we undo it, we can remember what it originally was.
+    pub first_history_move: Option<Move>,
+    pub state: HistoryState<T>
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/board/edges.rs
+++ b/src/board/edges.rs
@@ -7,7 +7,7 @@ use super::{
     Board, Cols, Rows,
 };
 
-pub type EdgeBuffer = u32;
+pub type EdgeBuffer = u16;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Edges<const T: usize> {
@@ -19,15 +19,15 @@ pub struct Edges<const T: usize> {
 }
 
 pub fn generate_edges<const T: usize>(buffer: EdgeBuffer, rows: Rows, cols: Cols) -> Edges<T> {
-    let top = !(BitBoard::max() << (buffer * cols) as u32);
-    let bottom = BitBoard::max() << ((rows - buffer) * cols) as u32;
+    let top = !(BitBoard::max() << (buffer * cols));
+    let bottom = BitBoard::max() << ((rows - buffer) * cols);
 
-    let mut left = BitBoard::max() & (!(BitBoard::max() << (buffer as u32)));
+    let mut left = BitBoard::max() & (!(BitBoard::max() << (buffer)));
     for _ in 1..rows {
         left |= (left << (cols));
     }
 
-    let right = left << (cols - buffer) as u32;
+    let right = left << (cols - buffer);
 
     let edges = top | bottom | left | right;
 

--- a/src/board/fen/args.rs
+++ b/src/board/fen/args.rs
@@ -24,7 +24,7 @@ impl<const T: usize> FenArgument<T> for FenTeamArgument {
     fn decode(&self, board: &mut Board<T>, arg: &str) -> Result<(), FenDecodeError> {
         match self {
             FenTeamArgument::Number => {
-                board.state.moving_team = arg.parse::<u32>().map_err(|_| {
+                board.state.moving_team = arg.parse::<u16>().map_err(|_| {
                     FenDecodeError::InvalidArgument(format!(
                         "{} is not a valid numerical team value",
                         arg
@@ -35,7 +35,7 @@ impl<const T: usize> FenArgument<T> for FenTeamArgument {
                 let team = teams.iter().position(|el| el.to_string() == arg);
                 match team {
                     Some(team) => {
-                        board.state.moving_team = team as u32;
+                        board.state.moving_team = team as u16;
                     }
                     None => {
                         return Err(FenDecodeError::InvalidArgument(format!(
@@ -60,7 +60,7 @@ impl<const T: usize> FenArgument<T> for FenTurns {
     }
 
     fn decode(&self, board: &mut Board<T>, arg: &str) -> Result<(), FenDecodeError> {
-        board.state.turns = arg.parse::<u32>().map_err(|_| {
+        board.state.turns = arg.parse::<u16>().map_err(|_| {
             FenDecodeError::InvalidArgument(format!(
                 "'{arg}' is not a valid amount of turns, as it isn't a positive integer."
             ))
@@ -78,7 +78,7 @@ impl<const T: usize> FenArgument<T> for FenSubMoves {
     }
 
     fn decode(&self, board: &mut Board<T>, arg: &str) -> Result<(), FenDecodeError> {
-        board.state.sub_moves = arg.parse::<u32>().map_err(|_| {
+        board.state.sub_moves = arg.parse::<u16>().map_err(|_| {
             FenDecodeError::InvalidArgument(format!(
                 "'{arg}' is not a valid amount of sub moves, as it isn't a positive integer."
             ))
@@ -96,7 +96,7 @@ impl<const T: usize> FenArgument<T> for FenFullMoves {
     }
 
     fn decode(&self, board: &mut Board<T>, arg: &str) -> Result<(), FenDecodeError> {
-        board.state.full_moves = arg.parse::<u32>().map_err(|_| {
+        board.state.full_moves = arg.parse::<u16>().map_err(|_| {
             FenDecodeError::InvalidArgument(format!(
                 "'{arg}' is not a valid amount of full moves, as it isn't a positive integer."
             ))

--- a/src/board/fen/state.rs
+++ b/src/board/fen/state.rs
@@ -27,7 +27,7 @@ impl<'a, const T: usize> Board<'a, T> {
                 if char.is_numeric() {
                     board_ind += char.to_digit(10).expect(&format!(
                         "Could not convert {char} to an integer in FEN state."
-                    ));
+                    )) as u16;
                     i += 1;
                     continue;
                 }

--- a/src/board/game.rs
+++ b/src/board/game.rs
@@ -7,7 +7,7 @@ use super::{actions::{Action, ActionInfo, TheoreticalAction, Move, TheoreticalMo
 pub fn get_theoretical_moves_bound<const T: usize>(board: &Board<T>, max_info: ActionInfo, can_pass: bool) -> Vec<TheoreticalMove> {
     let mut theoretical_moves = Vec::with_capacity(((
         (board.game.squares) + 1 * board.game.squares
-    ) as usize * max_info) + (can_pass as usize));
+    ) as usize * (max_info as usize)) + (can_pass as usize));
 
     if can_pass {
         theoretical_moves.push(TheoreticalMove::Pass);

--- a/src/board/game.rs
+++ b/src/board/game.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-pub const NORMAL_MODE: u32 = 0;
+pub const NORMAL_MODE: u16 = 0;
 
 use super::{actions::{Action, ActionInfo, TheoreticalAction, Move, TheoreticalMove}, fen::FenOptions, pieces::Piece, Board, Rows, Cols, zobrist::ZobristHashTable};
 
@@ -37,7 +37,7 @@ pub fn get_theoretical_moves_bound<const T: usize>(board: &Board<T>, max_info: A
 }
 
 pub trait MoveController<const T: usize> : Debug + Send + Sync {
-    fn transform_moves(&self, board: &mut Board<T>, mode: u32, actions: Vec<Move>) -> Vec<Move>;
+    fn transform_moves(&self, board: &mut Board<T>, mode: u16, actions: Vec<Move>) -> Vec<Move>;
     fn is_legal(&self, board: &mut Board<T>, action: &Move) -> bool;
     fn use_pseudolegal(&self) -> bool;
 
@@ -47,7 +47,7 @@ pub trait MoveController<const T: usize> : Debug + Send + Sync {
     }
 
     fn encode_action(&self, board: &Board<T>, action: &Move) -> Vec<String>;
-    fn decode_action(&self, board: &mut Board<T>, action: &str, mode: u32) -> Option<Move> {
+    fn decode_action(&self, board: &mut Board<T>, action: &str, mode: u16) -> Option<Move> {
         board.generate_moves(mode)
             .iter()
             .find(|el| self.encode_action(board, el).contains(&action.to_string()))
@@ -96,8 +96,9 @@ pub trait MoveController<const T: usize> : Debug + Send + Sync {
     fn get_max_available_moves(&self) -> u32;
 }
 
+#[derive(Debug, Copy, Clone)]
 pub enum GameResults {
-    Win(u32),
+    Win(u16),
     Draw,
     Ongoing
 }
@@ -122,11 +123,11 @@ pub struct Game<const T: usize> {
     pub resolution: Box<dyn Resolution<T>>,
     pub fen_options: FenOptions<T>,
     pub name: String,
-    pub teams: u32,
-    pub turns: u32,
+    pub teams: u16,
+    pub turns: u16,
     pub rows: Rows,
     pub cols: Cols,
-    pub squares: u32,
+    pub squares: u16,
     /// Anything not covered by first_moves, pieces, and gaps should be zobrist_info
     pub zobrist_controller: Box<dyn ZobristController<T>>,
     pub zobrist: ZobristHashTable<T>

--- a/src/board/game.rs
+++ b/src/board/game.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 pub const NORMAL_MODE: u16 = 0;
 
-use super::{actions::{Action, ActionInfo, TheoreticalAction, Move, TheoreticalMove}, fen::FenOptions, pieces::Piece, Board, Rows, Cols, zobrist::ZobristHashTable};
+use super::{actions::{Action, ActionInfo, TheoreticalAction, Move, TheoreticalMove, HistoryMove}, fen::FenOptions, pieces::Piece, Board, Rows, Cols, zobrist::ZobristHashTable};
 
 pub fn get_theoretical_moves_bound<const T: usize>(board: &Board<T>, max_info: ActionInfo, can_pass: bool) -> Vec<TheoreticalMove> {
     let mut theoretical_moves = Vec::with_capacity(((
@@ -42,7 +42,7 @@ pub trait MoveController<const T: usize> : Debug + Send + Sync {
     fn use_pseudolegal(&self) -> bool;
 
     fn add_moves(&self, board: &Board<T>, actions: &mut Vec<Move>) {}
-    fn make_drop_move(&self, board: &mut Board<T>, action: &Action) {
+    fn make_drop_move(&self, board: &mut Board<T>, action: &Action) -> Option<HistoryMove<T>> {
         panic!("Drop moves aren't supported. Make sure to override `make_drop_move` in your game's MoveController to support them.");
     }
 
@@ -128,6 +128,7 @@ pub struct Game<const T: usize> {
     pub rows: Rows,
     pub cols: Cols,
     pub squares: u16,
+    pub saved_last_moves: u16,
     /// Anything not covered by first_moves, pieces, and gaps should be zobrist_info
     pub zobrist_controller: Box<dyn ZobristController<T>>,
     pub zobrist: ZobristHashTable<T>

--- a/src/board/perft.rs
+++ b/src/board/perft.rs
@@ -38,9 +38,9 @@ impl<'a, const T: usize> Board<'a, T> {
             self.generate_moves(0)
         };
         for node in moves {
-            self.make_move(&node);
+            let undo = self.make_move(&node);
             nodes += self.perft(depth - 1, legality);
-            self.undo_move();
+            self.undo_move(undo);
         }
 
         nodes
@@ -77,11 +77,11 @@ impl<'a, const T: usize> Board<'a, T> {
         let mut nodes = 0;
         let mut branches: Vec<PerftBranch> = vec![];
         for node in self.generate_legal_moves(0) {
-            self.make_move(&node);
+            let undo = self.make_move(&node);
             let results = self.branch_perft(depth - 1);
             nodes += results.nodes;
             branches.push((self.encode_action(&node), results));
-            self.undo_move();
+            self.undo_move(undo);
         }
 
         PerftResults { nodes, branches }

--- a/src/board/pieces/mod.rs
+++ b/src/board/pieces/mod.rs
@@ -43,17 +43,17 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
         board: &Board<T>,
         from: BitBoard<T>,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
     ) -> BitBoard<T>;
     fn can_move_mask(
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        from_bit: u32,
+        from_bit: u16,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
         to: BitBoard<T>,
     ) -> BitBoard<T> {
         self.get_moves(board, from, piece_type, team, mode)
@@ -214,9 +214,9 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
         actions: &mut Vec<Move>,
         board: &Board<T>,
         piece_type: usize,
-        from: u32,
-        team: u32,
-        mode: u32,
+        from: u16,
+        team: u16,
+        mode: u16,
     ) {
         let from_board = BitBoard::from_lsb(from);
 

--- a/src/board/positions.rs
+++ b/src/board/positions.rs
@@ -13,7 +13,7 @@ const COLS: [char; 52] = [
 ];
 
 impl<'a, const T: usize> Board<'a, T> {
-    pub fn encode_position(&self, pos: u32) -> String {
+    pub fn encode_position(&self, pos: u16) -> String {
         let base_row = pos / self.state.cols;
         let col = pos - (self.state.cols * base_row);
         let row = self.state.rows - base_row;
@@ -21,7 +21,7 @@ impl<'a, const T: usize> Board<'a, T> {
         return format!("{}{}", COLS[col as usize], row);
     }
 
-    pub fn decode_position(&self, text: String) -> Result<u32, String> {
+    pub fn decode_position(&self, text: String) -> Result<u16, String> {
         let col = text
             .chars()
             .nth(0)
@@ -30,10 +30,10 @@ impl<'a, const T: usize> Board<'a, T> {
         let col = COLS
             .iter()
             .position(|el| el == &col)
-            .ok_or(format!("Cannot find board column from char '{col}'"))? as u32;
+            .ok_or(format!("Cannot find board column from char '{col}'"))? as u16;
         let row = self.state.rows
             - text[1..]
-                .parse::<u32>()
+                .parse::<u16>()
                 .map_err(|_| format!("Cannot find board row from char '{}'", &text[1..]))?;
 
         Ok(col + (self.state.cols * row))
@@ -43,7 +43,7 @@ impl<'a, const T: usize> Board<'a, T> {
         self.game.controller.encode_action(self, action)[0].clone()
     }
 
-    pub fn decode_action(&mut self, action: &str, mode: u32) -> Option<Move> {
+    pub fn decode_action(&mut self, action: &str, mode: u16) -> Option<Move> {
         self.game.controller.decode_action(self, action, mode)
     }
 }

--- a/src/board/util.rs
+++ b/src/board/util.rs
@@ -4,6 +4,7 @@ use std::fmt::Error;
 use std::fmt::Formatter;
 
 use arrayvec::ArrayVec;
+use std::collections::VecDeque;
 use fastrand;
 
 use crate::bitboard::BitBoard;
@@ -104,7 +105,7 @@ pub struct Board<'a, const T: usize> {
     pub state: BoardState<T>,
     pub game: &'a Game<T>,
     pub attack_lookup: Vec<AttackLookup<T>>,
-    pub history: ArrayVec<Move, 64>
+    pub history: VecDeque<Move>
 }
 
 impl<'a, const T: usize> Display for Board<'a, T> {
@@ -167,7 +168,7 @@ impl<'a, const T: usize> Board<'a, T> {
         let mut board = Board {
             attack_lookup: vec![],
             game,
-            history: ArrayVec::new(),
+            history: VecDeque::with_capacity(1),
             state: BoardState {
                 all_pieces: BitBoard::new(),
                 first_move: BitBoard::new(),
@@ -318,10 +319,10 @@ impl<'a, const T: usize> Board<'a, T> {
             return None;
         }
 
-        self.history.push(action);
+        self.history.push_back(action);
 
         if self.history.len() > self.game.saved_last_moves.into() {
-            self.history.swap_pop(0)
+            self.history.pop_front()
         } else {
             None
         }
@@ -333,8 +334,8 @@ impl<'a, const T: usize> Board<'a, T> {
         }
 
         if let Some(first_history_move) = first_history_move {
-            self.history.pop();
-            self.history.insert(0, first_history_move);
+            self.history.pop_back();
+            self.history.push_front(first_history_move);
         }
     }
 

--- a/src/board/zobrist.rs
+++ b/src/board/zobrist.rs
@@ -3,23 +3,23 @@ use super::{Board, game::Game};
 #[derive(Debug, Clone)]
 pub struct ZobristHashTable<const T: usize> {
     pub table: Vec<u64>,
-    pub squares: u32,
-    pub teams: u32,
-    pub pieces: u32,
+    pub squares: u16,
+    pub teams: u16,
+    pub pieces: u16,
     pub base_len: usize,
     pub extra_len: usize
 }
 
 impl<const T: usize> ZobristHashTable<T> {
-    fn get_gap_index(&self, position: u32) -> usize {
+    fn get_gap_index(&self, position: u16) -> usize {
         position as usize
     }
 
-    fn get_first_move_index(&self, position: u32) -> usize {
+    fn get_first_move_index(&self, position: u16) -> usize {
         (position + (self.squares)) as usize
     }
 
-    fn get_piece_index(&self, position: u32, piece_type: u32, team: u32) -> usize {
+    fn get_piece_index(&self, position: u16, piece_type: u16, team: u16) -> usize {
         (position + (self.squares * (1 + (piece_type + (self.pieces * team))))) as usize
     }
 
@@ -46,7 +46,7 @@ impl<const T: usize> ZobristHashTable<T> {
         hash
     }
 
-    pub fn generate(squares: u32, teams: u32, pieces: u32, extra_hashes: usize, get_random: impl Fn() -> u64) -> ZobristHashTable<T> {
+    pub fn generate(squares: u16, teams: u16, pieces: u16, extra_hashes: usize, get_random: impl Fn() -> u64) -> ZobristHashTable<T> {
         let hashes = (squares * (2 + (pieces * teams))) as usize;
         let base_len = (
             (squares - 1) + (squares * (1 + ((pieces - 1) + (pieces * (teams - 1))))) + 1

--- a/src/games/ataxx/controller.rs
+++ b/src/games/ataxx/controller.rs
@@ -65,7 +65,7 @@ impl<const T: usize> MoveController<T> for AtaxxMoveController {
                         format!(
                             "{}{}",
                             board.encode_position(action.to),
-                            board.game.pieces[action.piece_type].format_info(board, action.info)
+                            board.game.pieces[action.piece_type as usize].format_info(board, action.info)
                         )
                     } else {
                         if let Some(from) = action.from {
@@ -73,7 +73,7 @@ impl<const T: usize> MoveController<T> for AtaxxMoveController {
                                 "{}{}{}",
                                 board.encode_position(from),
                                 board.encode_position(action.to),
-                                board.game.pieces[action.piece_type].format_info(board, action.info)
+                                board.game.pieces[action.piece_type as usize].format_info(board, action.info)
                             )
                         } else {
                             "----".to_string()

--- a/src/games/ataxx/controller.rs
+++ b/src/games/ataxx/controller.rs
@@ -24,9 +24,9 @@ impl<const T: usize> MoveController<T> for AtaxxMoveController {
 
             let team_squares = board.state.teams[board.state.moving_team as usize];
 
-            board.make_move(&Move::Pass);
+            let undo = board.make_move(&Move::Pass);
             let opposing_moves = board.generate_moves(NORMAL_MODE).len();
-            board.undo_move();
+            board.undo_move(undo);
             if opposing_moves > 0 && empty_squares.count_ones() > 0 && team_squares.count_ones() > 0  {
                 vec![ Move::Pass ]
             } else {

--- a/src/games/ataxx/controller.rs
+++ b/src/games/ataxx/controller.rs
@@ -15,7 +15,7 @@ impl<const T: usize> MoveController<T> for AtaxxMoveController {
         return false;
     }
 
-    fn transform_moves(&self, board: &mut Board<T>, mode: u32, actions: Vec<Move>) -> Vec<Move> {
+    fn transform_moves(&self, board: &mut Board<T>, mode: u16, actions: Vec<Move>) -> Vec<Move> {
         // No Legal Moves
         if actions.len() == 0 {
             let board_mask = BitBoard::starting_at_lsb(0, 49);
@@ -34,7 +34,7 @@ impl<const T: usize> MoveController<T> for AtaxxMoveController {
             }
             
         } else {
-            let mut set = HashSet::<u32>::with_capacity(actions.len());
+            let mut set = HashSet::<u16>::with_capacity(actions.len());
             let mut new_actions = Vec::with_capacity(actions.len());
 
             for action in actions {

--- a/src/games/ataxx/game.rs
+++ b/src/games/ataxx/game.rs
@@ -24,6 +24,7 @@ impl Ataxx {
             rows: 7,
             cols: 7,
             squares: 49,
+            saved_last_moves: 0,
             zobrist_controller: Box::new(DefaultZobristController),
             zobrist: ZobristHashTable::<1>::generate(49, 2, 1, 0, || fastrand::u64(0..u64::MAX)),
             name: String::from("Ataxx"),

--- a/src/games/ataxx/pieces/mod.rs
+++ b/src/games/ataxx/pieces/mod.rs
@@ -54,8 +54,8 @@ impl<const T: usize> Piece<T> for StonePiece {
         board: &Board<T>,
         from: BitBoard<T>,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
     ) -> BitBoard<T> {
         let lookup = self.get_attack_lookup(board, piece_type);
         let base_moves = match lookup {

--- a/src/games/ataxx/pieces/mod.rs
+++ b/src/games/ataxx/pieces/mod.rs
@@ -1,6 +1,6 @@
 use std::usize;
 
-use crate::{board::{pieces::{Piece, PieceSymbol}, Board, AttackLookup, AttackDirections, actions::{Action, PreviousBoard, HistoryMove, HistoryState, HistoryUpdate, IndexedPreviousBoard, Move}, edges::Edges, Cols, update_turns}, bitboard::BitBoard};
+use crate::{board::{pieces::{Piece, PieceSymbol}, Board, AttackLookup, AttackDirections, actions::{Action, PreviousBoard, HistoryMove, HistoryState, HistoryUpdate, IndexedPreviousBoard, Move}, edges::Edges, Cols, update_turns, PieceType}, bitboard::BitBoard};
 
 use super::is_single_move;
 
@@ -53,7 +53,7 @@ impl<const T: usize> Piece<T> for StonePiece {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
     ) -> BitBoard<T> {
@@ -82,8 +82,8 @@ impl<const T: usize> Piece<T> for StonePiece {
                     first_move: PreviousBoard(board.state.first_move),
                     updates: vec![
                         HistoryUpdate::Piece(IndexedPreviousBoard(
-                            piece_type,
-                            board.state.pieces[piece_type],
+                            piece_type as usize,
+                            board.state.pieces[piece_type as usize],
                         )),
                         HistoryUpdate::Team(IndexedPreviousBoard(
                             team,
@@ -100,15 +100,15 @@ impl<const T: usize> Piece<T> for StonePiece {
             if is_single_move(action) {
                 // Single Moves
                 
-                board.state.pieces[piece_type] |= to;
+                board.state.pieces[piece_type as usize] |= to;
                 board.state.teams[team] |= to;
                 board.state.all_pieces |= to;
                 board.state.first_move &= !from;
             } else {
                 // Double Moves
 
-                board.state.pieces[piece_type] ^= from;
-                board.state.pieces[piece_type] |= to;
+                board.state.pieces[piece_type as usize] ^= from;
+                board.state.pieces[piece_type as usize] |= to;
                 board.state.teams[team] ^= from;
                 board.state.teams[team] |= to;
                 board.state.all_pieces ^= from;

--- a/src/games/ataxx/pieces/mod.rs
+++ b/src/games/ataxx/pieces/mod.rs
@@ -65,7 +65,7 @@ impl<const T: usize> Piece<T> for StonePiece {
         base_moves & !(board.state.all_pieces | board.state.gaps)
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: &Action) {
+    fn make_move(&self, board: &mut Board<T>, action: &Action) -> Option<HistoryMove<T>> {
         if let Some(from) = action.from {
             let from = BitBoard::<T>::from_lsb(from);
             let to = BitBoard::<T>::from_lsb(action.to);
@@ -74,8 +74,9 @@ impl<const T: usize> Piece<T> for StonePiece {
             let team = action.team as usize;
             let other_team = board.state.team_lookup[team] as usize;
 
-            board.history.push(HistoryMove {
+            let history_move = HistoryMove {
                 action: Move::Action(*action),
+                first_history_move: board.retrieve_first_history_move(Move::Action(*action)),
                 state: HistoryState::Any {
                     all_pieces: PreviousBoard(board.state.all_pieces),
                     first_move: PreviousBoard(board.state.first_move),
@@ -94,7 +95,7 @@ impl<const T: usize> Piece<T> for StonePiece {
                         )),
                     ],
                 },
-            });
+            };
 
             if is_single_move(action) {
                 // Single Moves
@@ -127,6 +128,10 @@ impl<const T: usize> Piece<T> for StonePiece {
             board.state.teams[team] |= to_update;
 
             update_turns(&mut board.state);
+
+            Some(history_move)
+        } else {
+            None
         }
     }
 }

--- a/src/games/chess/args.rs
+++ b/src/games/chess/args.rs
@@ -154,13 +154,13 @@ impl<const T: usize> FenArgument<T> for ChessEnPassant {
             move_type: 0
         };
 
-        board.history.push(Move::Action(action));
+        board.history.push_back(Move::Action(action));
 
         Ok(())
     }
 
     fn encode(&self, board: &Board<T>) -> String {
-        let last_move = (&board.history).last();
+        let last_move = (&board.history).iter().last();
         if let None = last_move {
             return "-".to_string();
         }

--- a/src/games/chess/args.rs
+++ b/src/games/chess/args.rs
@@ -145,17 +145,16 @@ impl<const T: usize> FenArgument<T> for ChessEnPassant {
         let to = up::<T>(&BitBoard::from_lsb(en_passant_target), 1, cols, 1);
         let from = down::<T>(&to, 2, cols, previous_team);
 
-        board.history.push(HistoryMove {
-            action: Move::Action(Action {
-                from: Some(from.bitscan_forward()),
-                to: to.bitscan_forward(),
-                team: previous_team,
-                piece_type: 0,
-                info: 0,
-                move_type: 0
-            }),
-            state: HistoryState::None,
-        });
+        let action = Action {
+            from: Some(from.bitscan_forward()),
+            to: to.bitscan_forward(),
+            team: previous_team,
+            piece_type: 0,
+            info: 0,
+            move_type: 0
+        };
+
+        board.history.push(Move::Action(action));
 
         Ok(())
     }
@@ -169,7 +168,7 @@ impl<const T: usize> FenArgument<T> for ChessEnPassant {
         let last_move =
             last_move.expect("The last move for exporting an en passant FEN must be Some.");
 
-        match last_move.action {
+        match last_move {
             Move::Action(last_action) => {
                 if last_action.piece_type != 0 {
                     return "-".to_string();

--- a/src/games/chess/controller.rs
+++ b/src/games/chess/controller.rs
@@ -57,7 +57,7 @@ impl<const T: usize> MoveController<T> for ChessMoveController<T> {
                             "{}{}{}",
                             board.encode_position(from),
                             board.encode_position(action.to),
-                            board.game.pieces[action.piece_type].format_info(board, action.info)
+                            board.game.pieces[action.piece_type as usize].format_info(board, action.info)
                         ),
                         None => "----".to_string()
                     }

--- a/src/games/chess/controller.rs
+++ b/src/games/chess/controller.rs
@@ -28,11 +28,11 @@ impl<const T: usize> MoveController<T> for ChessMoveController<T> {
 
                 let current_team = board.state.moving_team;
 
-                board.make_move(&Move::Action(*action));
+                let undo = board.make_move(&Move::Action(*action));
                 let kings = board.state.pieces[5];
                 let king_board = board.state.teams[current_team as usize] & kings;
                 let in_check = board.can_move(board.state.moving_team, king_board, ATTACKS_MODE);
-                board.undo_move();
+                board.undo_move(undo);
                 !in_check
             }
             Move::Pass => {

--- a/src/games/chess/controller.rs
+++ b/src/games/chess/controller.rs
@@ -6,7 +6,7 @@ use super::ATTACKS_MODE;
 pub struct ChessMoveController<const T: usize>;
 
 impl<const T: usize> MoveController<T> for ChessMoveController<T> {
-    fn transform_moves(&self, board: &mut Board<T>, mode: u32, actions: Vec<Move>) -> Vec<Move> {
+    fn transform_moves(&self, board: &mut Board<T>, mode: u16, actions: Vec<Move>) -> Vec<Move> {
         let moves = board.generate_moves(mode);
         let mut legal_moves = Vec::with_capacity(moves.len());
         for action in moves {

--- a/src/games/chess/game.rs
+++ b/src/games/chess/game.rs
@@ -17,7 +17,7 @@ use super::{pieces::{
     down, up, BishopPiece, KingPiece, KnightPiece, PawnPiece, QueenPiece, RookPiece,
 }, ChessMoveController, ChessPostProcess, ChessCastlingRights, ChessEnPassant, ChessResolution};
 
-pub const ATTACKS_MODE: u32 = 1;
+pub const ATTACKS_MODE: u16 = 1;
 
 const PAWN: &dyn Piece<1> = &PawnPiece;
 const KNIGHT: &dyn Piece<1> = &KnightPiece;

--- a/src/games/chess/game.rs
+++ b/src/games/chess/game.rs
@@ -36,6 +36,7 @@ impl Chess {
             rows: 8,
             cols: 8,
             squares: 64,
+            saved_last_moves: 1,
             zobrist_controller: Box::new(DefaultZobristController),
             zobrist: ZobristHashTable::<1>::generate(64, 2, 6, 65, || fastrand::u64(0..u64::MAX)),
             name: String::from("Chess"),

--- a/src/games/chess/pieces/king.rs
+++ b/src/games/chess/pieces/king.rs
@@ -11,10 +11,10 @@ use crate::{
     games::chess::game::ATTACKS_MODE,
 };
 
-const NORMAL_KING_MOVE: usize = 0;
-const CASTLING_MOVE: usize = 1;
+const NORMAL_KING_MOVE: u16 = 0;
+const CASTLING_MOVE: u16 = 1;
 
-const ROOK_PIECE_TYPE: usize = 3;
+const ROOK_PIECE_TYPE: PieceType = 3;
 
 #[derive(Debug)] pub struct KingPiece<const T: usize>;
 
@@ -59,7 +59,7 @@ impl<const T: usize> KingPiece<T> {
         };
 
         let color: usize = action.team as usize;
-        let piece_type = action.piece_type;
+        let piece_type = action.piece_type as usize;
 
         let history_move = HistoryMove {
             action: Move::Action(*action),
@@ -74,8 +74,8 @@ impl<const T: usize> KingPiece<T> {
                         board.state.pieces[piece_type],
                     )),
                     HistoryUpdate::Piece(IndexedPreviousBoard(
-                        ROOK_PIECE_TYPE,
-                        board.state.pieces[ROOK_PIECE_TYPE],
+                        ROOK_PIECE_TYPE as usize,
+                        board.state.pieces[ROOK_PIECE_TYPE as usize],
                     )),
                 ],
             },
@@ -85,7 +85,7 @@ impl<const T: usize> KingPiece<T> {
         board.state.teams[color] ^= to;
 
         board.state.pieces[piece_type] ^= from;
-        board.state.pieces[ROOK_PIECE_TYPE] ^= to;
+        board.state.pieces[ROOK_PIECE_TYPE as usize] ^= to;
 
         board.state.all_pieces ^= from;
         board.state.all_pieces ^= to;
@@ -93,7 +93,7 @@ impl<const T: usize> KingPiece<T> {
         match dir {
             Direction::LEFT => {
                 board.state.pieces[piece_type] |= castle_left_king;
-                board.state.pieces[ROOK_PIECE_TYPE] |= castle_left_rook;
+                board.state.pieces[ROOK_PIECE_TYPE as usize] |= castle_left_rook;
 
                 board.state.teams[color] |= castle_left_king;
                 board.state.teams[color] |= castle_left_rook;
@@ -103,7 +103,7 @@ impl<const T: usize> KingPiece<T> {
             }
             Direction::RIGHT => {
                 board.state.pieces[piece_type] |= castle_right_king;
-                board.state.pieces[ROOK_PIECE_TYPE] |= castle_right_rook;
+                board.state.pieces[ROOK_PIECE_TYPE as usize] |= castle_right_rook;
 
                 board.state.teams[color] |= castle_right_king;
                 board.state.teams[color] |= castle_right_rook;
@@ -144,7 +144,7 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         board: &Board<T>,
         from: BitBoard<T>,
         from_bit: u16,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
         to: BitBoard<T>,
@@ -157,7 +157,7 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
     ) -> BitBoard<T> {
@@ -172,7 +172,7 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         &self,
         board: &mut Board<T>,
         action: &Action,
-        piece_type: usize,
+        piece_type: PieceType,
         from: BitBoard<T>,
         to: BitBoard<T>,
     ) -> Option<HistoryMove<T>> {
@@ -181,6 +181,7 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         }
 
         let color: usize = action.team as usize;
+        let piece_type = piece_type as usize;
         let captured_color: usize = if (to & board.state.teams[0]).is_set() {
             0
         } else {
@@ -239,7 +240,7 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         &self,
         actions: &mut Vec<Move>,
         board: &Board<T>,
-        piece_type: usize,
+        piece_type: PieceType,
         from: u16,
         team: u16,
         mode: u16,
@@ -287,7 +288,7 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
             return;
         }
 
-        let rooks = board.state.pieces[ROOK_PIECE_TYPE] & team_board & first_move & bottom_row;
+        let rooks = board.state.pieces[ROOK_PIECE_TYPE as usize] & team_board & first_move & bottom_row;
 
         /*
             FRC Castling brings us to the same positions that traditional chess castling would.

--- a/src/games/chess/pieces/king.rs
+++ b/src/games/chess/pieces/king.rs
@@ -141,10 +141,10 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        from_bit: u32,
+        from_bit: u16,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
         to: BitBoard<T>,
     ) -> BitBoard<T> {
         self.get_attack_lookup(board, piece_type).expect("Could not find move lookup table for king")[from_bit as usize][0]
@@ -156,8 +156,8 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         board: &Board<T>,
         from: BitBoard<T>,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
     ) -> BitBoard<T> {
         let lookup = self.get_attack_lookup(board, piece_type);
         match lookup {
@@ -238,9 +238,9 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         actions: &mut Vec<Move>,
         board: &Board<T>,
         piece_type: usize,
-        from: u32,
-        team: u32,
-        mode: u32,
+        from: u16,
+        team: u16,
+        mode: u16,
     ) {
         let rows = board.state.rows;
         let cols = board.state.cols;

--- a/src/games/chess/pieces/knight.rs
+++ b/src/games/chess/pieces/knight.rs
@@ -77,10 +77,10 @@ impl<const T: usize> Piece<T> for KnightPiece<T> {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        from_bit: u32,
+        from_bit: u16,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
         to: BitBoard<T>,
     ) -> BitBoard<T> {
         self.get_attack_lookup(board, piece_type).expect("Could not find move lookup table for Knight")[from_bit as usize][0]
@@ -92,8 +92,8 @@ impl<const T: usize> Piece<T> for KnightPiece<T> {
         board: &Board<T>,
         from: BitBoard<T>,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
     ) -> BitBoard<T> {
         let lookup = self.get_attack_lookup(board, piece_type);
         match lookup {

--- a/src/games/chess/pieces/knight.rs
+++ b/src/games/chess/pieces/knight.rs
@@ -78,7 +78,7 @@ impl<const T: usize> Piece<T> for KnightPiece<T> {
         board: &Board<T>,
         from: BitBoard<T>,
         from_bit: u16,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
         to: BitBoard<T>,
@@ -91,7 +91,7 @@ impl<const T: usize> Piece<T> for KnightPiece<T> {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
     ) -> BitBoard<T> {

--- a/src/games/chess/pieces/pawn.rs
+++ b/src/games/chess/pieces/pawn.rs
@@ -19,7 +19,7 @@ fn promotion_move(piece_type: PieceType) -> usize {
 
 #[derive(Debug)] pub struct PawnPiece<const T: usize>;
 
-pub fn up<const T: usize>(bitboard: &BitBoard<T>, shift: u32, cols: Cols, team: u32) -> BitBoard<T> {
+pub fn up<const T: usize>(bitboard: &BitBoard<T>, shift: u16, cols: Cols, team: u16) -> BitBoard<T> {
     match team {
         0 => bitboard.up(shift, cols),
         1 => bitboard.down(shift, cols),
@@ -27,7 +27,7 @@ pub fn up<const T: usize>(bitboard: &BitBoard<T>, shift: u32, cols: Cols, team: 
     }
 }
 
-pub fn down<const T: usize>(bitboard: &BitBoard<T>, shift: u32, cols: Cols, team: u32) -> BitBoard<T> {
+pub fn down<const T: usize>(bitboard: &BitBoard<T>, shift: u16, cols: Cols, team: u16) -> BitBoard<T> {
     match team {
         0 => bitboard.down(shift, cols),
         1 => bitboard.up(shift, cols),
@@ -47,7 +47,7 @@ impl<const T: usize> PawnPiece<T> {
         let cols = board.state.cols;
 
         let color: usize = action.team as usize;
-        let en_passant_target = down(&to, 1, cols, color as u32);
+        let en_passant_target = down(&to, 1, cols, color as u16);
 
         let en_passant_target_color: usize = if (en_passant_target & board.state.teams[0]).is_set()
         {
@@ -161,10 +161,10 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        from_bit: u32,
+        from_bit: u16,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
         to: BitBoard<T>,
     ) -> BitBoard<T> {
         self.get_attack_lookup(board, piece_type).expect("Could not find pawn attack lookup")[from_bit as usize][team as usize]
@@ -175,8 +175,8 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
         board: &Board<T>,
         from: BitBoard<T>,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
     ) -> BitBoard<T> {
         let cols = board.state.cols;
         let edges = &board.state.edges[0];
@@ -370,9 +370,9 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
         actions: &mut Vec<Move>,
         board: &Board<T>,
         piece_type: usize,
-        from: u32,
-        team: u32,
-        mode: u32,
+        from: u16,
+        team: u16,
+        mode: u16,
     ) {
         let promotion_rows = board.state.edges[0].bottom | board.state.edges[0].top;
 

--- a/src/games/chess/pieces/pawn.rs
+++ b/src/games/chess/pieces/pawn.rs
@@ -205,7 +205,7 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
             moves |= double_moves;
         }
 
-        if let Some(last_move) = board.history.last() {
+        if let Some(last_move) = board.history.iter().last() {
             if let Move::Action(last_action) = last_move {
                 if let Some(from) = last_action.from {
                     let conditions = last_action.piece_type == 0
@@ -416,7 +416,7 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
                 }
             } else {
                 let mut en_passant = false;
-                if let Some(last_move) = board.history.last() {
+                if let Some(last_move) = board.history.iter().last() {
                     if let Move::Action(last_action) = last_move {
                         if let Some(from) = last_action.from {
                             let conditions = last_action.piece_type == 0

--- a/src/games/chess/pieces/sliders/bishop.rs
+++ b/src/games/chess/pieces/sliders/bishop.rs
@@ -53,10 +53,10 @@ impl<const T: usize> Piece<T> for BishopPiece {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        from_bit: u32,
+        from_bit: u16,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
         to: BitBoard<T>,
     ) -> BitBoard<T> {
         let lookup = self
@@ -84,8 +84,8 @@ impl<const T: usize> Piece<T> for BishopPiece {
         board: &Board<T>,
         from: BitBoard<T>,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
     ) -> BitBoard<T> {
         let lookup = self
             .get_attack_lookup(board, piece_type)

--- a/src/games/chess/pieces/sliders/bishop.rs
+++ b/src/games/chess/pieces/sliders/bishop.rs
@@ -54,7 +54,7 @@ impl<const T: usize> Piece<T> for BishopPiece {
         board: &Board<T>,
         from: BitBoard<T>,
         from_bit: u16,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
         to: BitBoard<T>,
@@ -83,7 +83,7 @@ impl<const T: usize> Piece<T> for BishopPiece {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
     ) -> BitBoard<T> {

--- a/src/games/chess/pieces/sliders/queen.rs
+++ b/src/games/chess/pieces/sliders/queen.rs
@@ -73,10 +73,10 @@ impl<const T: usize> Piece<T> for QueenPiece {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        from_bit: u32,
+        from_bit: u16,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
         to: BitBoard<T>,
     ) -> BitBoard<T> {
         let lookup = self
@@ -104,8 +104,8 @@ impl<const T: usize> Piece<T> for QueenPiece {
         board: &Board<T>,
         from: BitBoard<T>,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
     ) -> BitBoard<T> {
         let lookup = self
             .get_attack_lookup(board, piece_type)

--- a/src/games/chess/pieces/sliders/queen.rs
+++ b/src/games/chess/pieces/sliders/queen.rs
@@ -74,7 +74,7 @@ impl<const T: usize> Piece<T> for QueenPiece {
         board: &Board<T>,
         from: BitBoard<T>,
         from_bit: u16,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
         to: BitBoard<T>,
@@ -103,7 +103,7 @@ impl<const T: usize> Piece<T> for QueenPiece {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
     ) -> BitBoard<T> {

--- a/src/games/chess/pieces/sliders/rook.rs
+++ b/src/games/chess/pieces/sliders/rook.rs
@@ -50,7 +50,7 @@ impl<const T: usize> Piece<T> for RookPiece {
         board: &Board<T>,
         from: BitBoard<T>,
         from_bit: u16,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
         to: BitBoard<T>,
@@ -83,7 +83,7 @@ impl<const T: usize> Piece<T> for RookPiece {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        piece_type: usize,
+        piece_type: PieceType,
         team: u16,
         mode: u16,
     ) -> BitBoard<T> {

--- a/src/games/chess/pieces/sliders/rook.rs
+++ b/src/games/chess/pieces/sliders/rook.rs
@@ -49,10 +49,10 @@ impl<const T: usize> Piece<T> for RookPiece {
         &self,
         board: &Board<T>,
         from: BitBoard<T>,
-        from_bit: u32,
+        from_bit: u16,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
         to: BitBoard<T>,
     ) -> BitBoard<T> {
         let lookup = self
@@ -84,8 +84,8 @@ impl<const T: usize> Piece<T> for RookPiece {
         board: &Board<T>,
         from: BitBoard<T>,
         piece_type: usize,
-        team: u32,
-        mode: u32,
+        team: u16,
+        mode: u16,
     ) -> BitBoard<T> {
         let lookup = self
             .get_attack_lookup(board, piece_type)

--- a/src/games/chess/zobrist.rs
+++ b/src/games/chess/zobrist.rs
@@ -14,7 +14,7 @@ impl<const T: usize> ZobristController<T> for ChessZobrist<T> {
         let last_move =
             last_move.expect("The last move for exporting an en passant FEN must be Some.");
 
-        match last_move.action {
+        match last_move {
             Move::Action(last_action) => {
                 if last_action.piece_type != 0 {
                     *hash ^= zobrist.table[zobrist.base_len];

--- a/src/games/chess/zobrist.rs
+++ b/src/games/chess/zobrist.rs
@@ -5,7 +5,7 @@ pub struct ChessZobrist<const T: usize>;
 
 impl<const T: usize> ZobristController<T> for ChessZobrist<T> {
     fn apply(&self, hash: &mut u64, zobrist: &mut ZobristHashTable<T>, board: &mut Board<T>) {
-        let last_move = (&board.history).last();
+        let last_move = (&board.history).iter().last();
         if let None = last_move {
             *hash ^= zobrist.table[zobrist.base_len];
             return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,20 @@
+use monster_chess::games::chess::Chess;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn get_time_ms() -> u128 {
+    let start = SystemTime::now();
+    let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    since_the_epoch.as_millis()
+}
+
+fn main() {
+    let chess = Chess::create();
+    let mut board = chess.default();
+
+    let start = get_time_ms();
+    board.perft(5, false);
+    let end = get_time_ms();
+    println!("{}", end - start);
+}  


### PR DESCRIPTION
This pull request serves to update two things:

1. Actions currently store `from` and `to` as u32, allowing for 65,536 x 65,536 boards. This is infeasible for any use-cases `monster-chess` targets and comes at the cost of memory and performance, so moving to u16 is best.

2. `undo_move` currently adds onto `history`, a well-optimized ArrayVec that increases the cost of this. This is expensive though. To further complicate matters, `history` is also used for information like en passant. This PR will divide this into two subproblems:
- 2.1: Remove all undo logic from `history`. The undo information will be provided as the return value from `make_move`, and provided to tell it what to reset in `undo_move`.
- 2.2: Change `history` to only accept the last `n` moves (`n` configured by the `Game`), and to store `Action` instead of `HistoryMove`.