### PR TITLE
Fix update_turns updating after

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "monster_chess"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "criterion",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monster_chess"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 license = "MIT"
 description = "A fairy chess movegen library that can be easily extended to new chess-adjacent games."

--- a/src/board/pieces/mod.rs
+++ b/src/board/pieces/mod.rs
@@ -172,14 +172,14 @@ pub trait Piece<const T: usize> : Debug + Send + Sync {
         if let Some(from) = action.from {
             let from = BitBoard::from_lsb(from);
             let to = BitBoard::from_lsb(action.to);
+            
+            update_turns(&mut board.state, &board.game, &Move::Action(*action));
 
             let history_move = if (board.state.all_pieces & to).is_empty() {
                 self.make_normal_move(board, action, action.piece_type, from, to)
             } else {
                 self.make_capture_move(board, action, action.piece_type, from, to)
             };
-
-            update_turns(&mut board.state, &board.game, &Move::Action(*action));
 
             history_move
         } else {

--- a/src/games/ataxx/pieces/mod.rs
+++ b/src/games/ataxx/pieces/mod.rs
@@ -67,6 +67,8 @@ impl<const T: usize> Piece<T> for StonePiece {
 
     fn make_move(&self, board: &mut Board<T>, action: &Action) -> Option<HistoryMove<T>> {
         if let Some(from) = action.from {
+            update_turns(&mut board.state, &board.game, &Move::Action(*action));
+            
             let from = BitBoard::<T>::from_lsb(from);
             let to = BitBoard::<T>::from_lsb(action.to);
 
@@ -127,8 +129,6 @@ impl<const T: usize> Piece<T> for StonePiece {
 
             board.state.teams[other_team] ^= to_update;
             board.state.teams[team] |= to_update;
-
-            update_turns(&mut board.state, &board.game, &Move::Action(*action));
 
             Some(history_move)
         } else {


### PR DESCRIPTION
This fixes a major bug where `update_turns` updates after `make_move`, which messes up the half-moves counter resetting in Chess, for instance.