### PR TITLE
Update turn_info incrementing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "monster_chess"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monster_chess"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 license = "MIT"
 description = "A fairy chess movegen library that can be easily extended to new chess-adjacent games."

--- a/src/games/ataxx/pieces/mod.rs
+++ b/src/games/ataxx/pieces/mod.rs
@@ -76,10 +76,11 @@ impl<const T: usize> Piece<T> for StonePiece {
             let team = action.team as usize;
             let other_team = board.state.team_lookup[team] as usize;
 
+            let turn_info = board.get_turn_info();
             let history_move = HistoryMove {
                 action: Move::Action(*action),
                 first_history_move: board.retrieve_first_history_move(Move::Action(*action)),
-                turn_info: board.get_turn_info(),
+                turn_info,
                 state: HistoryState::Any {
                     all_pieces: PreviousBoard(board.state.all_pieces),
                     first_move: PreviousBoard(board.state.first_move),

--- a/src/games/chess/pieces/king.rs
+++ b/src/games/chess/pieces/king.rs
@@ -2,7 +2,7 @@ use crate::{
     bitboard::{Direction, BitBoard},
     board::{
         actions::{
-            Action, HistoryMove, HistoryState, HistoryUpdate, IndexedPreviousBoard, PreviousBoard, Move,
+            Action, HistoryMove, HistoryState, HistoryUpdate, IndexedPreviousBoard, PreviousBoard, Move, TurnInfo,
         },
         edges::Edges,
         pieces::{Piece, PieceSymbol},
@@ -35,7 +35,7 @@ fn down_one<const T: usize>(from: BitBoard<T>, cols: Cols, edges: &Edges<T>) -> 
 }
 
 impl<const T: usize> KingPiece<T> {
-    fn make_castling_move(&self, board: &mut Board<T>, action: &Action, from: BitBoard<T>, to: BitBoard<T>) -> Option<HistoryMove<T>> {
+    fn make_castling_move(&self, board: &mut Board<T>, action: &Action, from: BitBoard<T>, to: BitBoard<T>, turn_info: TurnInfo) -> Option<HistoryMove<T>> {
         let cols = board.state.cols;
         let mut left_center = BitBoard::from_lsb(if cols % 2 == 0 {
             (cols / 2) - 1
@@ -63,7 +63,7 @@ impl<const T: usize> KingPiece<T> {
 
         let history_move = HistoryMove {
             action: Move::Action(*action),
-            turn_info: board.get_turn_info(),
+            turn_info,
             first_history_move: board.retrieve_first_history_move(Move::Action(*action)),
             state: HistoryState::Any {
                 all_pieces: PreviousBoard(board.state.all_pieces),
@@ -176,9 +176,10 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         piece_type: PieceType,
         from: BitBoard<T>,
         to: BitBoard<T>,
+        turn_info: TurnInfo
     ) -> Option<HistoryMove<T>> {
         if action.move_type == CASTLING_MOVE {
-            return self.make_castling_move(board, action, from, to);
+            return self.make_castling_move(board, action, from, to, turn_info);
         }
 
         let color: usize = action.team as usize;
@@ -199,7 +200,7 @@ impl<const T: usize> Piece<T> for KingPiece<T> {
         let history_move = HistoryMove {
             action: Move::Action(*action),
             first_history_move: board.retrieve_first_history_move(Move::Action(*action)),
-            turn_info: board.get_turn_info(),
+            turn_info,
             state: HistoryState::Any {
                 all_pieces: PreviousBoard(board.state.all_pieces),
                 first_move: PreviousBoard(board.state.first_move),

--- a/src/games/chess/pieces/pawn.rs
+++ b/src/games/chess/pieces/pawn.rs
@@ -2,7 +2,7 @@ use crate::{
     bitboard::{Direction, BitBoard},
     board::{
         actions::{
-            Action, HistoryMove, HistoryState, HistoryUpdate, IndexedPreviousBoard, PreviousBoard, Move, ActionInfo,
+            Action, HistoryMove, HistoryState, HistoryUpdate, IndexedPreviousBoard, PreviousBoard, Move, ActionInfo, TurnInfo,
         },
         edges::Edges,
         pieces::{Piece, PieceSymbol},
@@ -43,6 +43,7 @@ impl<const T: usize> PawnPiece<T> {
         piece_type: PieceType,
         from: BitBoard<T>,
         to: BitBoard<T>,
+        turn_info: TurnInfo
     ) -> Option<HistoryMove<T>> {
         let cols = board.state.cols;
 
@@ -60,7 +61,7 @@ impl<const T: usize> PawnPiece<T> {
         let history_move = HistoryMove {
             action: Move::Action(*action),
             first_history_move: board.retrieve_first_history_move(Move::Action(*action)),
-            turn_info: board.get_turn_info(),
+            turn_info,
             state: HistoryState::Any {
                 all_pieces: PreviousBoard(board.state.all_pieces),
                 first_move: PreviousBoard(board.state.first_move),
@@ -239,6 +240,7 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
         piece_type: PieceType,
         from: BitBoard<T>,
         to: BitBoard<T>,
+        turn_info: TurnInfo
     ) -> Option<HistoryMove<T>> {
         let color: usize = action.team as usize;
         let piece_type = piece_type as usize;
@@ -258,7 +260,7 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
         let mut history_move = HistoryMove {
             action: Move::Action(*action),
             first_history_move: board.retrieve_first_history_move(Move::Action(*action)),
-            turn_info: board.get_turn_info(),
+            turn_info,
             state: HistoryState::Any {
                 all_pieces: PreviousBoard(board.state.all_pieces),
                 first_move: PreviousBoard(board.state.first_move),
@@ -323,9 +325,10 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
         piece_type: PieceType,
         from: BitBoard<T>,
         to: BitBoard<T>,
+        turn_info: TurnInfo
     ) -> Option<HistoryMove<T>> {
         if action.move_type == EN_PASSANT_MOVE {
-            return self.make_en_passant_move(board, action, piece_type, from, to);
+            return self.make_en_passant_move(board, action, piece_type, from, to, turn_info);
         }
 
         let color: usize = action.team as usize;
@@ -334,7 +337,7 @@ impl<const T: usize> Piece<T> for PawnPiece<T> {
         let mut history_move = HistoryMove {
             action: Move::Action(*action),
             first_history_move: board.retrieve_first_history_move(Move::Action(*action)),
-            turn_info: board.get_turn_info(),
+            turn_info,
             state: HistoryState::Single {
                 team: IndexedPreviousBoard(color, board.state.teams[color]),
                 piece: IndexedPreviousBoard(piece_type, board.state.pieces[piece_type]),

--- a/src/games/chess/pieces/sliders/util.rs
+++ b/src/games/chess/pieces/sliders/util.rs
@@ -34,8 +34,7 @@ pub fn get_ray_attacks<const T: usize>(
 ) -> BitBoard<T> {
     let dir_usize = dir as usize;
     let mut attacks = ray_attacks[from_bit][dir_usize];
-    let mut blocker = attacks;
-    blocker &= board.state.all_pieces;
+    let blocker = attacks & board.state.all_pieces;
     if blocker.is_set() {
         let square = if from < blocker {
             blocker.bitscan_forward()


### PR DESCRIPTION
This fixes a bug where `turn_info` doesn't probably reset on `undo_move`.