### PR TITLE
Bug Fix: Transforms shouldn't take ownership of `files` or `transforms`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "monster_chess"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "criterion",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monster_chess"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2021"
 license = "MIT"
 description = "A fairy chess movegen library that can be easily extended to new chess-adjacent games."

--- a/src/bitboard/transforms.rs
+++ b/src/bitboard/transforms.rs
@@ -32,7 +32,7 @@ pub fn generate_files<const T: usize>(cols: Cols, rows: Rows) -> Vec<BitBoard<T>
 }
 
 impl<const T: usize> BitBoard<T> {
-    pub fn flip_vertically(self, ranks: Vec<BitBoard<T>>, cols: Cols, rows: Rows) -> BitBoard<T> {
+    pub fn flip_vertically(self, ranks: &Vec<BitBoard<T>>, cols: Cols, rows: Rows) -> BitBoard<T> {
         let mut new_board = BitBoard::<T>::new();
         let max_rank = rows - 1;
 
@@ -57,7 +57,7 @@ impl<const T: usize> BitBoard<T> {
         new_board
     }
 
-    pub fn flip_horizontally(self, files: Vec<BitBoard<T>>, cols: Cols) -> BitBoard<T> {
+    pub fn flip_horizontally(self, files: &Vec<BitBoard<T>>, cols: Cols) -> BitBoard<T> {
         let mut new_board = BitBoard::<T>::new();
 
         let max_file = cols - 1;


### PR DESCRIPTION
`flip_vertically` and `flip_horizontally` will now take in a borrow of `files` and `transforms`, not ownership.